### PR TITLE
Fix formatting of result units

### DIFF
--- a/data.py
+++ b/data.py
@@ -100,12 +100,14 @@ class BenchData:
         unit = self.unit
         if unit == "KB/s":
             mean_of_means = humanize.naturalsize(mean_of_means * 1000, format="%.3f")
+            mean_of_means = f"{mean_of_means}/s"
             stdev_of_means = humanize.naturalsize(stdev_of_means * 1000, format="%.3f")
+            stdev_of_means = f"{stdev_of_means}/s"
         else:
             mean_of_means = f"{mean_of_means:.2f}{unit}"
             stdev_of_means = f"{stdev_of_means:.2f}{unit}"
 
-        return f"Mean {mean_of_means}/s +- {stdev_of_means}/s"
+        return f"Mean {mean_of_means} +- {stdev_of_means}"
 
 
 if __name__ == "__main__":

--- a/graphs.py
+++ b/graphs.py
@@ -74,6 +74,7 @@ class Benchmarks(UserDict):
             m = statistics.mean(d.means)
             if d.unit == "KB/s":
                 m = humanize.naturalsize(m * 1000, format="%.1f")
+                m = f"{m}/s"
             else:
                 if m > 1000:
                     m = m / 1000.0
@@ -82,7 +83,7 @@ class Benchmarks(UserDict):
                     unit = d.unit
                 m = f"{m:.1f} {unit}"
 
-            label = f"{label}, mean={m}/s"
+            label = f"{label}, mean={m}"
 
         return label
 


### PR DESCRIPTION
The previous implementation incorrectly rendered IOPS values with unit IOPS/s.

This commit corrects the unit rendering to always correctly render IOPS and `[kMG]?B/s` units.